### PR TITLE
build: update pre-commit pylint hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,4 +34,5 @@ repos:
         name: pylint
         entry: pylint
         language: system
+        files: ^src/
         types: [python]

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ To install incendium on your Gateway follow these steps:
     1. If you're replacing a previous version, make sure to check Allow Overwrite
 1. Click on **Import**
 
-Alternatively you could follow the instructions for cloning the `project` branch directly into `$IGNITION_DIR/data/projects` found [here](https://github.com/ignition-incendium/incendium/tree/project#cloning-this-branch).
+Alternatively you could follow the instructions for cloning the `project` repo directly into `$IGNITION_DIR/data/projects` found [here](https://github.com/ignition-incendium/project?tab=readme-ov-file#cloning-this-repo).
 
 ## Contributing to `incendium`
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](https://github.com/ignition-incendium/.github/blob/main/CONTRIBUTING.md#contributing-to-incendium).
 
 ## Discussions
 
@@ -111,4 +111,4 @@ See [LICENSE](./LICENSE).
 
 ## Code of conduct
 
-See [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
+See [CODE_OF_CONDUCT.md](https://github.com/ignition-incendium/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,10 @@ env_list =
 
 [testenv:install]
 description = install package
-base_python = {[py2]base_python}
+base_python = python2.7
 
 [testenv:typecheck]
 description = run type check on code base
-base_python = {[type]base_python}
 skip_install = true
 deps =
     {[type]deps}
@@ -21,7 +20,6 @@ commands =
 
 [testenv:stubgen]
 description = generate stubs
-base_python = {[type]base_python}
 skip_install = true
 deps =
     {[type]deps}
@@ -30,7 +28,6 @@ commands =
 
 [testenv:style]
 description = apply style
-base_python = {[py3]base_python}
 skip_install = true
 deps =
     black
@@ -49,13 +46,6 @@ commands =
 allowlist_externals =
     bash
 
-[py2]
-base_python = python2.7
-
-[py3]
-base_python = python3.12
-
 [type]
-base_python = {[py3]base_python}
 deps =
     ignition-api-stubs


### PR DESCRIPTION
when pylint is installed isolated from pre-commit, e.g. with pipx,
it flags setup.py with E0401 since setuptools is not found
update tox config