### PR TITLE
ci: bump coatl-dev/workflows from 3 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v4
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/pr-build.yml'
       - requirements/dev.txt
       - 'src/**'
       - Makefile
@@ -17,4 +18,4 @@ jobs:
 
   tox:
     needs: jython
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v4

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit-autoupdate:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit-autoupdate.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/pre-commit-autoupdate.yml@v4
     with:
       skip-repos: 'flake8'
     secrets:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,13 @@ on:
 
 jobs:
   pre-commit:
-    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/pre-commit.yml@v4
     with:
       skip-hooks: 'pylint'
 
   pylint:
     needs: pre-commit
-    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/pylint.yml@v4
 
   jython:
     needs: pylint
@@ -21,11 +21,11 @@ jobs:
 
   tox:
     needs: jython
-    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/tox-docker.yml@v4
 
   pypi-publish:
     needs: tox
-    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v3
+    uses: coatl-dev/workflows/.github/workflows/pypi-upload.yml@v4
     with:
       python-version: '2.7'
     secrets:


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflows to use the latest version (v4) of the coatl-dev/workflows repository, ensuring compatibility and leveraging any improvements or fixes in the new version.

- **CI**:
    - Updated GitHub Actions workflows to use version 4 of coatl-dev/workflows instead of version 3.

<!-- Generated by sourcery-ai[bot]: end summary -->